### PR TITLE
Fix for issue #10 -- Broken persistent sessions.

### DIFF
--- a/src/com/amazon/speech/speechlet/SpeechletResponse.java
+++ b/src/com/amazon/speech/speechlet/SpeechletResponse.java
@@ -13,8 +13,6 @@ package com.amazon.speech.speechlet;
 import com.amazon.speech.ui.Card;
 import com.amazon.speech.ui.OutputSpeech;
 import com.amazon.speech.ui.Reprompt;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 /**
  * The response to a {@code Speechlet} invocation. Defines text to speak to the user, content to
@@ -54,7 +52,6 @@ public class SpeechletResponse {
      * 
      * @return whether the session should end
      */
-    @JsonInclude(Include.NON_DEFAULT)
     public boolean getShouldEndSession() {
         return shouldEndSession;
     }


### PR DESCRIPTION
This change simply removes the Jackson annotation that is preventing "false" values for shouldEndSession from being serialized to json.
