### PR TITLE
Adding locale to Intent- and Launch-Request (immediate demand!)

### DIFF
--- a/src/com/amazon/speech/speechlet/IntentRequest.java
+++ b/src/com/amazon/speech/speechlet/IntentRequest.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("IntentRequest")
 public class IntentRequest extends SpeechletRequest {
     private final Intent intent;
+    private final String locale;
 
     /**
      * Returns a new builder instance used to construct a new {@code IntentRequest}.
@@ -45,6 +46,7 @@ public class IntentRequest extends SpeechletRequest {
     private IntentRequest(final Builder builder) {
         super(builder.requestId, builder.timestamp);
         this.intent = builder.intent;
+        this.locale = builder.locale;
     }
 
     /**
@@ -54,15 +56,25 @@ public class IntentRequest extends SpeechletRequest {
      *            the request identifier.
      * @param timestamp
      *            the request timestamp.
+     * @param locale
+     *            the request locale.
      * @param intent
      *            the intent to handle.
      */
     protected IntentRequest(@JsonProperty("requestId") final String requestId,
-            @JsonProperty("timestamp") final Date timestamp,
+            @JsonProperty("timestamp") final Date timestamp, @JsonProperty("locale") final String locale,
             @JsonProperty("intent") final Intent intent) {
         super(requestId, timestamp);
         this.intent = intent;
+        this.locale = locale;
     }
+
+    /**
+     * Returns the request locale.
+     *
+     * @return the request locale.
+     */
+    public final String getLocale() { return locale; }
 
     /**
      * Returns the intent associated with this request. For a new session, the {@code Intent} passed
@@ -82,6 +94,7 @@ public class IntentRequest extends SpeechletRequest {
      */
     public static final class Builder {
         private String requestId;
+        private String locale;
         private Date timestamp = new Date();
         private Intent intent;
 
@@ -95,6 +108,11 @@ public class IntentRequest extends SpeechletRequest {
 
         public Builder withTimestamp(final Date timestamp) {
             this.timestamp = (timestamp != null) ? new Date(timestamp.getTime()) : null;
+            return this;
+        }
+
+        public Builder withLocale(final String locale) {
+            this.locale = locale;
             return this;
         }
 

--- a/src/com/amazon/speech/speechlet/LaunchRequest.java
+++ b/src/com/amazon/speech/speechlet/LaunchRequest.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  */
 @JsonTypeName("LaunchRequest")
 public final class LaunchRequest extends SpeechletRequest {
+    private final String locale;
+
     /**
      * Returns a new builder instance used to construct a new {@code LaunchRequest}.
      *
@@ -41,6 +43,7 @@ public final class LaunchRequest extends SpeechletRequest {
      */
     private LaunchRequest(final Builder builder) {
         super(builder.requestId, builder.timestamp);
+        this.locale = builder.locale;
     }
 
     /**
@@ -48,19 +51,30 @@ public final class LaunchRequest extends SpeechletRequest {
      *
      * @param requestId
      *            the unique identifier associated with the request
+     * @param locale
+     *            the locale associated with the request
      * @param timestamp
      *            the request timestamp
      */
-    private LaunchRequest(@JsonProperty("requestId") final String requestId,
+    private LaunchRequest(@JsonProperty("requestId") final String requestId, @JsonProperty("locale") final String locale,
             @JsonProperty("timestamp") final Date timestamp) {
         super(requestId, timestamp);
+        this.locale = locale;
     }
+
+    /**
+     * Returns the request locale.
+     *
+     * @return the request locale.
+     */
+    public final String getLocale() { return locale; }
 
     /**
      * Builder used to construct a new {@code LaunchRequest}.
      */
     public static final class Builder {
         private String requestId;
+        private String locale;
         private Date timestamp = new Date();
 
         private Builder() {
@@ -73,6 +87,11 @@ public final class LaunchRequest extends SpeechletRequest {
 
         public Builder withTimestamp(final Date timestamp) {
             this.timestamp = (timestamp != null) ? new Date(timestamp.getTime()) : null;
+            return this;
+        }
+
+        public Builder withLocale(final String locale) {
+            this.locale = locale;
             return this;
         }
 


### PR DESCRIPTION
We really need the multilanguage-feature of Alexa in this SDK for building localized skills.

This PR contains:
- Maps locale-parameter from JSON input to IntentRequest and LaunchRequest
- withLocale for builders of both request-objects
- new Getter for both of the request-objects to read out locale from within the Speechlet implementation

This contribution is under the terms of the Apache 2.0 license.

Immediate action is desired for not having dirty workarounds / custom extensions around this SDK.
Thanks in advance.
