### PR TITLE
mistakable app id identifier and missing documentation

### DIFF
--- a/samples/src/main/java/helloworld/HelloWorldSpeechletRequestStreamHandler.java
+++ b/samples/src/main/java/helloworld/HelloWorldSpeechletRequestStreamHandler.java
@@ -28,7 +28,7 @@ public final class HelloWorldSpeechletRequestStreamHandler extends SpeechletRequ
          * This Id can be found on https://developer.amazon.com/edw/home.html#/ "Edit" the relevant
          * Alexa Skill and put the relevant Application Ids in this Set.
          */
-        supportedApplicationIds.add("amzn1.echo-sdk-ams.app.[unique-value-here]");
+        supportedApplicationIds.add("[unique-id-value-here]");
     }
 
     public HelloWorldSpeechletRequestStreamHandler() {

--- a/samples/src/main/java/helloworld/README.md
+++ b/samples/src/main/java/helloworld/README.md
@@ -7,7 +7,7 @@ This simple sample has no external dependencies or session management, and shows
 ## Setup
 To run this example skill you need to do two things. The first is to deploy the example code in lambda, and the second is to configure the Alexa skill to use Lambda.
 
-### AWS Lambda Setup
+### AWS Lambda Setup - First part
 1. Go to the AWS Console and click on the Lambda link. Note: ensure you are in us-east or you wont be able to use Alexa with Lambda.
 2. Click on the Create a Lambda Function or Get Started Now button.
 3. Skip the blueprint
@@ -33,6 +33,15 @@ To run this example skill you need to do two things. The first is to deploy the 
 7. You are now able to start testing your sample skill! You should be able to go to the [Echo webpage](http://echo.amazon.com/#skills) and see your skill enabled.
 8. In order to test it, try to say some of the Sample Utterances from the Examples section below.
 9. Your skill is now saved and once you are finished testing you can continue to publish your skill.
+
+### Connecting AWS Lambda with your Alexa Skill
+
+1. The Application Id of your Skill can be found on https://developer.amazon.com/edw/home.html#/ "Edit" the relevant Alexa Skill and copy the relevant Application Id to the clipboard.
+2. Paste the Application Id of your Alexa Skill to you HelloWorldSpeechletRequestStreamHandler class.
+3. Go to the AWS Console and click on the Lambda link.
+7. Go to the the root directory containing pom.xml, and run 'mvn assembly:assembly -DdescriptorId=jar-with-dependencies package'. This will generate a zip file named "alexa-skills-kit-samples-1.0-jar-with-dependencies.jar" in the target directory.
+8. Again, upload the "alexa-skills-kit-samples-1.0-jar-with-dependencies.jar" file from the build directory to Lambda. Click Save.
+
 
 ## Examples
 ### One-shot model:

--- a/samples/src/main/java/helloworld/README.md
+++ b/samples/src/main/java/helloworld/README.md
@@ -39,8 +39,8 @@ To run this example skill you need to do two things. The first is to deploy the 
 1. The Application Id of your Skill can be found on https://developer.amazon.com/edw/home.html#/ "Edit" the relevant Alexa Skill and copy the relevant Application Id to the clipboard.
 2. Paste the Application Id of your Alexa Skill to you HelloWorldSpeechletRequestStreamHandler class.
 3. Go to the AWS Console and click on the Lambda link.
-7. Go to the the root directory containing pom.xml, and run 'mvn assembly:assembly -DdescriptorId=jar-with-dependencies package'. This will generate a zip file named "alexa-skills-kit-samples-1.0-jar-with-dependencies.jar" in the target directory.
-8. Again, upload the "alexa-skills-kit-samples-1.0-jar-with-dependencies.jar" file from the build directory to Lambda. Click Save.
+4. Go to the the root directory containing pom.xml, and run 'mvn assembly:assembly -DdescriptorId=jar-with-dependencies package'. This will generate a zip file named "alexa-skills-kit-samples-1.0-jar-with-dependencies.jar" in the target directory.
+5. Again, upload the "alexa-skills-kit-samples-1.0-jar-with-dependencies.jar" file from the build directory to Lambda. Click Save.
 
 
 ## Examples

--- a/samples/src/main/java/helloworld/README.md
+++ b/samples/src/main/java/helloworld/README.md
@@ -7,7 +7,7 @@ This simple sample has no external dependencies or session management, and shows
 ## Setup
 To run this example skill you need to do two things. The first is to deploy the example code in lambda, and the second is to configure the Alexa skill to use Lambda.
 
-### AWS Lambda Setup - First part
+### AWS Lambda Setup
 1. Go to the AWS Console and click on the Lambda link. Note: ensure you are in us-east or you wont be able to use Alexa with Lambda.
 2. Click on the Create a Lambda Function or Get Started Now button.
 3. Skip the blueprint

--- a/samples/src/main/java/historybuff/HistoryBuffSpeechletRequestStreamHandler.java
+++ b/samples/src/main/java/historybuff/HistoryBuffSpeechletRequestStreamHandler.java
@@ -32,7 +32,7 @@ public class HistoryBuffSpeechletRequestStreamHandler extends SpeechletRequestSt
          * Alexa Skill and put the relevant Application Ids in this Set.
          */
         supportedApplicationIds = new HashSet<String>();
-        // supportedApplicationIds.add("amzn1.echo-sdk-ams.app.[unique-value-here]");
+        // supportedApplicationIds.add("[unique-id-value-here]");
     }
 
     public HistoryBuffSpeechletRequestStreamHandler() {

--- a/samples/src/main/java/minecrafthelper/MinecraftHelperSpeechletRequestStreamHandler.java
+++ b/samples/src/main/java/minecrafthelper/MinecraftHelperSpeechletRequestStreamHandler.java
@@ -28,7 +28,7 @@ public final class MinecraftHelperSpeechletRequestStreamHandler extends
          * Alexa Skill and put the relevant Application Ids in this Set.
          */
         supportedApplicationIds = new HashSet<String>();
-        // supportedApplicationIds.add("amzn1.echo-sdk-ams.app.[unique-value-here]");
+        // supportedApplicationIds.add("[unique-id-value-here]");
     }
 
     public MinecraftHelperSpeechletRequestStreamHandler() {

--- a/samples/src/main/java/savvyconsumer/SavvyConsumerSpeechletRequestStreamHandler.java
+++ b/samples/src/main/java/savvyconsumer/SavvyConsumerSpeechletRequestStreamHandler.java
@@ -27,7 +27,7 @@ public final class SavvyConsumerSpeechletRequestStreamHandler extends SpeechletR
          * Alexa Skill and put the relevant Application Ids in this Set.
          */
         supportedApplicationIds = new HashSet<String>();
-        // supportedApplicationIds.add("amzn1.echo-sdk-ams.app.[unique-value-here]");
+        // supportedApplicationIds.add("[unique-id-value-here]");
     }
 
     public SavvyConsumerSpeechletRequestStreamHandler() {

--- a/samples/src/main/java/scorekeeper/ScoreKeeperSpeechletRequestStreamHandler.java
+++ b/samples/src/main/java/scorekeeper/ScoreKeeperSpeechletRequestStreamHandler.java
@@ -30,7 +30,7 @@ public final class ScoreKeeperSpeechletRequestStreamHandler extends SpeechletReq
          * Alexa Skill and put the relevant Application Ids in this Set.
          */
         supportedApplicationIds = new HashSet<String>();
-        // supportedApplicationIds.add("amzn1.echo-sdk-ams.app.[unique-value-here]");
+        // supportedApplicationIds.add("[unique-id-value-here]");
     }
 
     public ScoreKeeperSpeechletRequestStreamHandler() {

--- a/samples/src/main/java/session/SessionSpeechletRequestStreamHandler.java
+++ b/samples/src/main/java/session/SessionSpeechletRequestStreamHandler.java
@@ -30,7 +30,7 @@ public class SessionSpeechletRequestStreamHandler extends SpeechletRequestStream
          * Alexa Skill and put the relevant Application Ids in this Set.
          */
         supportedApplicationIds = new HashSet<String>();
-        // supportedApplicationIds.add("amzn1.echo-sdk-ams.app.[unique-value-here]");
+        // supportedApplicationIds.add("[unique-id-value-here]");
     }
 
     public SessionSpeechletRequestStreamHandler() {

--- a/samples/src/main/java/spacegeek/SpaceGeekSpeechletRequestStreamHandler.java
+++ b/samples/src/main/java/spacegeek/SpaceGeekSpeechletRequestStreamHandler.java
@@ -30,7 +30,7 @@ public final class SpaceGeekSpeechletRequestStreamHandler extends SpeechletReque
          * Alexa Skill and put the relevant Application Ids in this Set.
          */
         supportedApplicationIds = new HashSet<String>();
-        // supportedApplicationIds.add("amzn1.echo-sdk-ams.app.[unique-value-here]");
+        // supportedApplicationIds.add("[unique-id-value-here]");
     }
 
     public SpaceGeekSpeechletRequestStreamHandler() {

--- a/samples/src/main/java/tidepooler/TidePoolerSpeechletRequestStreamHandler.java
+++ b/samples/src/main/java/tidepooler/TidePoolerSpeechletRequestStreamHandler.java
@@ -32,7 +32,7 @@ public class TidePoolerSpeechletRequestStreamHandler extends SpeechletRequestStr
          * Alexa Skill and put the relevant Application Ids in this Set.
          */
         supportedApplicationIds = new HashSet<String>();
-        // supportedApplicationIds.add("amzn1.echo-sdk-ams.app.[unique-value-here]");
+        // supportedApplicationIds.add("[unique-id-value-here]");
     }
 
     public TidePoolerSpeechletRequestStreamHandler() {

--- a/samples/src/main/java/wiseguy/WiseGuySpeechletRequestStreamHandler.java
+++ b/samples/src/main/java/wiseguy/WiseGuySpeechletRequestStreamHandler.java
@@ -32,7 +32,7 @@ public class WiseGuySpeechletRequestStreamHandler extends SpeechletRequestStream
          * Alexa Skill and put the relevant Application Ids in this Set.
          */
         supportedApplicationIds = new HashSet<String>();
-        // supportedApplicationIds.add("amzn1.echo-sdk-ams.app.[unique-value-here]");
+        // supportedApplicationIds.add("[unique-id-value-here]");
     }
 
     public WiseGuySpeechletRequestStreamHandler() {


### PR DESCRIPTION
The prefix amzn1.echo-sdk-ams.app is not valid for all skills. This leads to error because my skills start with an "amzn1.ask.skill.[UNIQUE_ID]" prefix

The documentation doesn't mention the application ids that need to be added to the HelloWorldSpeechletRequestStreamHandler class