### PR TITLE
Fix failing tests for servlet support package on JDK 9 build

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,5 @@
+# ASK SDK for Java [![Build Status](https://travis-ci.org/alexa/alexa-skills-kit-sdk-for-java.png?branch=2.0.x)](https://travis-ci.org/alexa/alexa-skills-kit-sdk-for-java)
+
 The ASK SDK for Java makes it easier for you to build highly engaging skills, by allowing you to spend more time on implementing features and less on writing boiler-plate code.
 
 To help you get started more with the SDK we have included several samples, references, and guides. We've collected links to all of them here to make them easy to find, as well as a description for what each document covers.

--- a/ask-sdk-servlet-support/pom.xml
+++ b/ask-sdk-servlet-support/pom.xml
@@ -69,13 +69,13 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
-      <version>1.7.3</version>
+      <version>2.0.0-beta.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>1.7.3</version>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>2.0.0-beta.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/ask-sdk-servlet-support/tst/com/amazon/ask/servlet/SkillServletTest.java
+++ b/ask-sdk-servlet-support/tst/com/amazon/ask/servlet/SkillServletTest.java
@@ -75,7 +75,7 @@ public class SkillServletTest extends SkillServletTestBase {
     @Test
     public void doPost_failedVerification_responseBadRequest() throws Exception {
         SkillServletVerifier mockVerifier = mock(SkillServletVerifier.class);
-        doThrow(new SecurityException()).when(mockVerifier).verify(any(), any(), any());
+        doThrow(new SecurityException("foo")).when(mockVerifier).verify(any(), any(), any());
         SkillServlet servlet = new SkillServlet(skill, Collections.singletonList(mockVerifier));
         OffsetDateTime timestamp = OffsetDateTime.ofInstant(new Date().toInstant(), ZoneId.systemDefault());
         LaunchRequest request = LaunchRequest.builder().withRequestId("rId").withLocale(LOCALE).withTimestamp(timestamp).build();


### PR DESCRIPTION
Fix failing test for servlet support package builds running on JDK 9 due to Powermock 1.x/JDK9 incompatibility.