### PR TITLE
Add null check for trim output speech method

### DIFF
--- a/ask-sdk-core/src/com/amazon/ask/response/ResponseBuilder.java
+++ b/ask-sdk-core/src/com/amazon/ask/response/ResponseBuilder.java
@@ -354,6 +354,9 @@ public class ResponseBuilder {
      * @return trimmed output speech
      */
     private String trimOutputSpeech(String outputSpeech) {
+        if (outputSpeech == null) {
+            return "";
+        }
         String trimmedOutputSpeech = outputSpeech.trim();
         if (trimmedOutputSpeech.startsWith("<speak>") && trimmedOutputSpeech.endsWith("</speak>")) {
             return trimmedOutputSpeech.substring(8, trimmedOutputSpeech.length() - 8).trim();

--- a/ask-sdk-core/tst/com/amazon/ask/response/ResponseBuilderTest.java
+++ b/ask-sdk-core/tst/com/amazon/ask/response/ResponseBuilderTest.java
@@ -517,4 +517,17 @@ public class ResponseBuilderTest {
                 .build();
         assertEquals(responseWithBuilder.get(), response);
     }
+
+    @Test
+    public void build_response_with_empty_speech() {
+        Response response = Response.builder()
+                .withOutputSpeech(SsmlOutputSpeech.builder()
+                        .withSsml("<speak></speak>")
+                        .build())
+                .build();
+        Optional<Response> responseWithBuilder = builder
+                .withSpeech(null)
+                .build();
+        assertEquals(responseWithBuilder.get(), response);
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Response Builder throws NPE if a withSpeech or withReprompt is used with null values. It should return an empty speech or response object instead.

## Description
<!--- Describe your changes in detail -->
'withSpeech' and 'withReprompt' calls 'trimOutputSpeech' method and
fails with NPE if a null is passed as variable. This commit checks if
the passed value is null and returns an empty string instead, in
trimOutputSpeech method.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
Fixes NPE thrown during Response Builder build method

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test added for the fix.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-java/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

