### PR TITLE
Add methods for serialize/deserialize directly to streams in Serializer

### DIFF
--- a/ask-sdk-core/src/com/amazon/ask/util/JacksonSerializer.java
+++ b/ask-sdk-core/src/com/amazon/ask/util/JacksonSerializer.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 /**
  * Jackson backed implementation of {@link Serializer}
@@ -51,9 +53,27 @@ public final class JacksonSerializer implements Serializer {
     }
 
     @Override
+    public <T> void serialize(T object, OutputStream outputStream) {
+        try {
+            mapper.writeValue(outputStream, object);
+        } catch (IOException e) {
+            throw new AskSdkException("Deserialization error");
+        }
+    }
+
+    @Override
     public <T> T deserialize(String s, Class<T> aClass) {
         try {
             return mapper.readValue(s, aClass);
+        } catch (IOException e) {
+            throw new AskSdkException("Deserialization error", e);
+        }
+    }
+
+    @Override
+    public <T> T deserialize(InputStream inputStream, Class<T> type) {
+        try {
+            return mapper.readValue(inputStream, type);
         } catch (IOException e) {
             throw new AskSdkException("Deserialization error", e);
         }

--- a/ask-sdk-core/tst/com/amazon/ask/util/JacksonSerializerTest.java
+++ b/ask-sdk-core/tst/com/amazon/ask/util/JacksonSerializerTest.java
@@ -23,9 +23,12 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -46,7 +49,7 @@ public class JacksonSerializerTest {
     }
 
     @Test
-    public void serialize_correct_input_to_mapper() throws IOException {
+    public void serialize_to_string_correct_input_to_mapper() throws IOException {
         ArgumentCaptor<ResponseEnvelope> captor = ArgumentCaptor.forClass(ResponseEnvelope.class);
         when(mockMapper.writeValueAsString(responseEnvelope)).thenReturn("foo");
         serializer.serialize(responseEnvelope);
@@ -55,13 +58,22 @@ public class JacksonSerializerTest {
     }
 
     @Test
-    public void serialize_correct_output_from_serializer() throws IOException {
+    public void serialize_to_string_correct_output_from_serializer() throws IOException {
         when(mockMapper.writeValueAsString(responseEnvelope)).thenReturn("foo");
         assertEquals(serializer.serialize(responseEnvelope), "foo");
     }
 
     @Test
-    public void deserialize_correct_input_to_serializer() throws IOException {
+    public void serialize_to_stream_correct_input_to_mapper() throws IOException {
+        OutputStream os = mock(OutputStream.class);
+        ArgumentCaptor<ResponseEnvelope> captor = ArgumentCaptor.forClass(ResponseEnvelope.class);
+        serializer.serialize(responseEnvelope, os);
+        verify(mockMapper).writeValue(any(OutputStream.class), captor.capture());
+        assertEquals(captor.getValue(), responseEnvelope);
+    }
+
+    @Test
+    public void deserialize_from_string_correct_input_to_serializer() throws IOException {
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         when(mockMapper.readValue("foo", RequestEnvelope.class)).thenReturn(requestEnvelope);
         serializer.deserialize("foo", RequestEnvelope.class);
@@ -70,21 +82,53 @@ public class JacksonSerializerTest {
     }
 
     @Test
-    public void deserialize_correct_output_from_mapper() throws IOException {
+    public void deserialize_from_string_correct_output_from_mapper() throws IOException {
         when(mockMapper.readValue("foo", RequestEnvelope.class)).thenReturn(requestEnvelope);
         assertEquals(serializer.deserialize("foo", RequestEnvelope.class), requestEnvelope);
     }
 
+    @Test
+    public void deserialize_from_stream_correct_input_to_serializer() throws IOException {
+        InputStream is = mock(InputStream.class);
+        ArgumentCaptor<InputStream> captor = ArgumentCaptor.forClass(InputStream.class);
+        when(mockMapper.readValue(is, RequestEnvelope.class)).thenReturn(requestEnvelope);
+        serializer.deserialize(is, RequestEnvelope.class);
+        verify(mockMapper).readValue(captor.capture(), any(Class.class));
+        assertEquals(captor.getValue(), is);
+    }
+
+    @Test
+    public void deserialize_from_stream_correct_output_from_mapper() throws IOException {
+        InputStream is = mock(InputStream.class);
+        when(mockMapper.readValue(is, RequestEnvelope.class)).thenReturn(requestEnvelope);
+        assertEquals(serializer.deserialize(is, RequestEnvelope.class), requestEnvelope);
+    }
+
     @Test(expected = AskSdkException.class)
-    public void serialize_ioexception_throws_sdk_exception() throws Exception {
+    public void serialize_from_string_ioexception_throws_sdk_exception() throws Exception {
         JsonProcessingException exception = mock(JsonProcessingException.class);
         when(mockMapper.writeValueAsString(responseEnvelope)).thenThrow(exception);
         serializer.serialize(responseEnvelope);
     }
 
     @Test(expected = AskSdkException.class)
-    public void deserialize_ioexception_throws_sdk_exception() throws Exception {
+    public void serialize_from_stream_ioexception_throws_sdk_exception() throws Exception {
+        OutputStream os = mock(OutputStream.class);
+        JsonProcessingException exception = mock(JsonProcessingException.class);
+        doThrow(exception).when(mockMapper).writeValue(os, responseEnvelope);
+        serializer.serialize(responseEnvelope, os);
+    }
+
+    @Test(expected = AskSdkException.class)
+    public void deserialize_from_string_ioexception_throws_sdk_exception() throws Exception {
         when(mockMapper.readValue("foo", RequestEnvelope.class)).thenThrow(new IOException());
         serializer.deserialize("foo", RequestEnvelope.class);
+    }
+
+    @Test(expected = AskSdkException.class)
+    public void deserialize_from_stream_ioexception_throws_sdk_exception() throws Exception {
+        InputStream is = mock(InputStream.class);
+        when(mockMapper.readValue(is, RequestEnvelope.class)).thenThrow(new IOException());
+        serializer.deserialize(is, RequestEnvelope.class);
     }
 }


### PR DESCRIPTION
Adding the ability to serialize and deserialize directly from output and input streams respectively. This bypasses any need for intermediate formats (String) and the necessity to create intermediate byte arrays.

