### PR TITLE
Surface exception if table does not exist on persistence getAttributes

### DIFF
--- a/ask-sdk-dynamodb-persistence-adapter/src/com/amazon/ask/attributes/persistence/impl/DynamoDbPersistenceAdapter.java
+++ b/ask-sdk-dynamodb-persistence-adapter/src/com/amazon/ask/attributes/persistence/impl/DynamoDbPersistenceAdapter.java
@@ -80,9 +80,7 @@ public final class DynamoDbPersistenceAdapter implements PersistenceAdapter {
         try {
             result = dynamoDb.getItem(request).getItem();
         } catch (ResourceNotFoundException e) {
-            if (!autoCreateTable) {
-                throw new PersistenceException(String.format("Table %s does not exist or is in the process of being created", tableName), e);
-            }
+            throw new PersistenceException(String.format("Table %s does not exist or is in the process of being created", tableName), e);
         } catch (AmazonDynamoDBException e) {
             throw new PersistenceException("Failed to retrieve attributes from DynamoDB", e);
         }

--- a/ask-sdk-dynamodb-persistence-adapter/tst/com/amazon/ask/attributes/persistence/impl/DynamoDbPersistenceAdapterTest.java
+++ b/ask-sdk-dynamodb-persistence-adapter/tst/com/amazon/ask/attributes/persistence/impl/DynamoDbPersistenceAdapterTest.java
@@ -179,12 +179,12 @@ public class DynamoDbPersistenceAdapterTest {
         verify(mockDdb, never()).createTable(any());
     }
 
-    @Test
-    public void get_attributes_returns_empty_if_auto_create_enabled_and_table_does_not_exist() {
+    @Test(expected = PersistenceException.class)
+    public void get_attributes_throws_exception_if_auto_create_enabled_and_table_does_not_exist() {
         when(mockKeyGenerator.apply(requestEnvelope)).thenReturn("bar");
         when(mockDdb.getItem(any())).thenThrow(new ResourceNotFoundException(""));
         PersistenceAdapter adapter = DynamoDbPersistenceAdapter.builder().withAutoCreateTable(true).withTableName("foo").withDynamoDbClient(mockDdb).withPartitionKeyGenerator(mockKeyGenerator).build();
-        assertEquals(adapter.getAttributes(requestEnvelope), Optional.empty());
+        adapter.getAttributes(requestEnvelope);
     }
 
     @Test(expected = PersistenceException.class)


### PR DESCRIPTION
## Description
Surfaces exception if table does not exist in all cases for persistence attributes .get(). Consistent with NodeJS implementation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-java/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

