### PR TITLE
Introduce module component for SDK extensions

### DIFF
--- a/ask-sdk-core/src/com/amazon/ask/builder/SkillConfiguration.java
+++ b/ask-sdk-core/src/com/amazon/ask/builder/SkillConfiguration.java
@@ -21,6 +21,7 @@ import com.amazon.ask.dispatcher.exception.ExceptionMapper;
 import com.amazon.ask.dispatcher.request.handler.HandlerAdapter;
 import com.amazon.ask.dispatcher.request.mapper.RequestMapper;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -105,8 +106,28 @@ public class SkillConfiguration {
         private Builder() {
         }
 
+        public Builder addRequestMapper(RequestMapper requestMapper) {
+            if (requestMappers == null) {
+                requestMappers = new ArrayList<>();
+            }
+            requestMappers.add(requestMapper);
+            return this;
+        }
+
         public Builder withRequestMappers(List<RequestMapper> requestMappers) {
             this.requestMappers = requestMappers;
+            return this;
+        }
+
+        public List<RequestMapper> getRequestMappers() {
+            return requestMappers;
+        }
+
+        public Builder addHandlerAdapter(HandlerAdapter handlerAdapter) {
+            if (handlerAdapters == null) {
+                handlerAdapters = new ArrayList<>();
+            }
+            handlerAdapters.add(handlerAdapter);
             return this;
         }
 
@@ -115,8 +136,32 @@ public class SkillConfiguration {
             return this;
         }
 
+        public List<HandlerAdapter> getHandlerAdapters() {
+            return handlerAdapters;
+        }
+
+        public Builder addRequestInterceptor(RequestInterceptor requestInterceptor) {
+            if (requestInterceptors == null) {
+                requestInterceptors = new ArrayList<>();
+            }
+            requestInterceptors.add(requestInterceptor);
+            return this;
+        }
+
         public Builder withRequestInterceptors(List<RequestInterceptor> requestInterceptors) {
             this.requestInterceptors = requestInterceptors;
+            return this;
+        }
+
+        public List<RequestInterceptor> getRequestInterceptors() {
+            return requestInterceptors;
+        }
+
+        public Builder addResponseInterceptor(ResponseInterceptor responseInterceptor) {
+            if (responseInterceptors == null) {
+                this.responseInterceptors = new ArrayList<>();
+            }
+            responseInterceptors.add(responseInterceptor);
             return this;
         }
 
@@ -125,9 +170,17 @@ public class SkillConfiguration {
             return this;
         }
 
+        public List<ResponseInterceptor> getResponseInterceptors() {
+            return responseInterceptors;
+        }
+
         public Builder withExceptionMapper(ExceptionMapper exceptionMapper) {
             this.exceptionMapper = exceptionMapper;
             return this;
+        }
+
+        public ExceptionMapper getExceptionMapper() {
+            return exceptionMapper;
         }
 
         public Builder withPersistenceAdapter(PersistenceAdapter persistenceAdapter) {
@@ -140,9 +193,17 @@ public class SkillConfiguration {
             return this;
         }
 
+        public ApiClient getApiClient() {
+            return apiClient;
+        }
+
         public Builder withCustomUserAgent(String customUserAgent) {
             this.customUserAgent = customUserAgent;
             return this;
+        }
+
+        public String getCustomUserAgent() {
+            return customUserAgent;
         }
 
         public Builder withSkillId(String skillId) {
@@ -150,9 +211,18 @@ public class SkillConfiguration {
             return this;
         }
 
+        public String getSkillId() {
+            return skillId;
+        }
+
         public SkillConfiguration build() {
             return new SkillConfiguration(requestMappers, handlerAdapters, requestInterceptors, responseInterceptors,
                     exceptionMapper, persistenceAdapter, apiClient, customUserAgent, skillId);
         }
+
+        public PersistenceAdapter getPersistenceAdapter() {
+            return persistenceAdapter;
+        }
+
     }
 }

--- a/ask-sdk-core/src/com/amazon/ask/dispatcher/impl/DefaultRequestDispatcher.java
+++ b/ask-sdk-core/src/com/amazon/ask/dispatcher/impl/DefaultRequestDispatcher.java
@@ -61,7 +61,7 @@ public class DefaultRequestDispatcher implements RequestDispatcher {
                                        Collection<RequestInterceptor> requestInterceptors, Collection<ResponseInterceptor> responseInterceptors) {
         this.handlerAdapters = ValidationUtils.assertNotNull(handlerAdapters, "handlerAdapters");
         this.requestMappers = ValidationUtils.assertNotEmpty(requestMappers, "requestMappers");
-        this.exceptionMapper = ValidationUtils.assertNotNull(exceptionMapper, "exceptionMapper");
+        this.exceptionMapper = exceptionMapper;
         this.requestInterceptors = requestInterceptors != null ? requestInterceptors : new ArrayList<>();
         this.responseInterceptors = responseInterceptors != null ? responseInterceptors : new ArrayList<>();
     }
@@ -76,7 +76,8 @@ public class DefaultRequestDispatcher implements RequestDispatcher {
         try {
             return doDispatch(input);
         } catch (Exception e) {
-            Optional<ExceptionHandler> exceptionHandler = exceptionMapper.getHandler(input, e);
+            Optional<ExceptionHandler> exceptionHandler = exceptionMapper != null
+                    ? exceptionMapper.getHandler(input, e) : Optional.empty();
             if (exceptionHandler.isPresent()) {
                 logger.debug("[{}] Found suitable exception handler", requestId);
                 return exceptionHandler.get().handle(input, e);

--- a/ask-sdk-core/src/com/amazon/ask/module/SdkModule.java
+++ b/ask-sdk-core/src/com/amazon/ask/module/SdkModule.java
@@ -11,12 +11,22 @@
     the specific language governing permissions and limitations under the License.
  */
 
-package com.amazon.ask.builder;
+package com.amazon.ask.module;
 
 import com.amazon.ask.Skill;
+import com.amazon.ask.builder.SkillBuilder;
+import com.amazon.ask.builder.SkillConfiguration;
 
 /**
- * Builder used to construct a new {@link Skill} without any additional modules.
- * Direct passthrough to {@link SkillBuilder}.
+ * An interface for SDK extensions that can be registered on the {@link SkillBuilder} when setting up
+ * a {@link Skill} instance.
  */
-public class CustomSkillBuilder extends SkillBuilder<CustomSkillBuilder> {}
+public interface SdkModule {
+
+    /**
+     * Method called by the {@link SkillBuilder} when .build() is called. Allows this module to configure
+     * itself as part of {@link SkillConfiguration} building.
+     */
+    void setupModule(SdkModuleContext context);
+
+}

--- a/ask-sdk-core/src/com/amazon/ask/module/SdkModuleContext.java
+++ b/ask-sdk-core/src/com/amazon/ask/module/SdkModuleContext.java
@@ -1,0 +1,100 @@
+/*
+    Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+    except in compliance with the License. A copy of the License is located at
+
+        http://aws.amazon.com/apache2.0/
+
+    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+    the specific language governing permissions and limitations under the License.
+ */
+
+package com.amazon.ask.module;
+
+import com.amazon.ask.attributes.persistence.PersistenceAdapter;
+import com.amazon.ask.builder.SkillConfiguration;
+import com.amazon.ask.dispatcher.exception.ExceptionMapper;
+import com.amazon.ask.dispatcher.request.handler.HandlerAdapter;
+import com.amazon.ask.dispatcher.request.interceptor.RequestInterceptor;
+import com.amazon.ask.dispatcher.request.interceptor.ResponseInterceptor;
+import com.amazon.ask.dispatcher.request.mapper.RequestMapper;
+import com.amazon.ask.exception.AskSdkException;
+import com.amazon.ask.model.services.ApiClient;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Context object passed to {@link SdkModule} implementations during module setup.
+ * Allows modules to configure themselves against the skill instance.
+ */
+public class SdkModuleContext {
+
+    protected final SkillConfiguration.Builder skillConfigBuilder;
+
+    public SdkModuleContext(SkillConfiguration.Builder skillConfigBuilder) {
+        this.skillConfigBuilder = skillConfigBuilder;
+    }
+
+    public SdkModuleContext addRequestMapper(RequestMapper requestMapper) {
+        skillConfigBuilder.addRequestMapper(requestMapper);
+        return this;
+    }
+
+    public List<RequestMapper> getRequestMappers() {
+        return Collections.unmodifiableList(skillConfigBuilder.getRequestMappers());
+    }
+
+    public SdkModuleContext addHandlerAdapter(HandlerAdapter handlerAdapter) {
+        skillConfigBuilder.addHandlerAdapter(handlerAdapter);
+        return this;
+    }
+
+    public List<HandlerAdapter> getHandlerAdapter() {
+        return Collections.unmodifiableList(skillConfigBuilder.getHandlerAdapters());
+    }
+
+    public SdkModuleContext addRequestInterceptor(RequestInterceptor requestInterceptor) {
+        skillConfigBuilder.addRequestInterceptor(requestInterceptor);
+        return this;
+    }
+
+    public List<RequestInterceptor> getRequestInterceptors() {
+        return Collections.unmodifiableList(skillConfigBuilder.getRequestInterceptors());
+    }
+
+    public SdkModuleContext addResponseInterceptor(ResponseInterceptor responseInterceptor) {
+        skillConfigBuilder.addResponseInterceptor(responseInterceptor);
+        return this;
+    }
+
+    public List<ResponseInterceptor> getResponseInterceptors() {
+        return Collections.unmodifiableList(skillConfigBuilder.getResponseInterceptors());
+    }
+
+    public SdkModuleContext setExceptionMapper(ExceptionMapper exceptionMapper) {
+        skillConfigBuilder.withExceptionMapper(exceptionMapper);
+        return this;
+    }
+
+    public SdkModuleContext setPersistenceAdapter(PersistenceAdapter persistenceAdapter) {
+        if (skillConfigBuilder.getPersistenceAdapter() != null) {
+            throw new AskSdkException("Conflicting persistence adapter configuration: " +
+                    "module attempting to override previously set value.");
+        }
+        skillConfigBuilder.withPersistenceAdapter(persistenceAdapter);
+        return this;
+    }
+
+    public SdkModuleContext setApiClient(ApiClient apiClient) {
+        if (skillConfigBuilder.getApiClient() != null) {
+            throw new AskSdkException("Conflicting API client configuration: " +
+                    "module attempting to override previously set value.");
+        }
+        skillConfigBuilder.withApiClient(apiClient);
+        return this;
+    }
+
+}

--- a/ask-sdk-core/tst/com/amazon/ask/builder/SkillBuilderTest.java
+++ b/ask-sdk-core/tst/com/amazon/ask/builder/SkillBuilderTest.java
@@ -27,6 +27,8 @@ import com.amazon.ask.model.Intent;
 import com.amazon.ask.model.IntentRequest;
 import com.amazon.ask.model.RequestEnvelope;
 import com.amazon.ask.model.services.ApiClient;
+import com.amazon.ask.module.SdkModule;
+import com.amazon.ask.module.SdkModuleContext;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -35,9 +37,10 @@ import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class CustomSkillBuilderTest {
+public class SkillBuilderTest {
 
     private CustomSkillBuilder builder;
     private RequestHandler mockRequestHandler;
@@ -98,7 +101,7 @@ public class CustomSkillBuilderTest {
     }
 
     @Test
-    public void no_custom_persistene_adapter_null() {
+    public void no_custom_persistence_adapter_null() {
         builder.addRequestHandler(mockRequestHandler);
         builder.withPersistenceAdapter(null);
         SkillConfiguration config = builder.getConfigBuilder().build();
@@ -129,6 +132,15 @@ public class CustomSkillBuilderTest {
         builder.withApiClient(apiClient);
         SkillConfiguration config = builder.getConfigBuilder().build();
         assertEquals(config.getApiClient(), apiClient);
+    }
+
+    @Test
+    public void sdk_module_executed() {
+        SdkModule mockModule = mock(SdkModule.class);
+        builder.addRequestHandler(mockRequestHandler);
+        builder.registerSdkModule(mockModule);
+        builder.build();
+        verify(mockModule).setupModule(any(SdkModuleContext.class));
     }
 
     private HandlerInput getInputForIntent(String intentName) {

--- a/ask-sdk-core/tst/com/amazon/ask/dispatcher/DefaultRequestDispatcherTest.java
+++ b/ask-sdk-core/tst/com/amazon/ask/dispatcher/DefaultRequestDispatcherTest.java
@@ -101,8 +101,8 @@ public class DefaultRequestDispatcherTest {
                 .build();
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void no_exception_mapper_throws_exception() {
+    @Test
+    public void no_exception_mapper_no_exception() {
         DefaultRequestDispatcher.builder()
                 .addRequestMapper(mockMapper)
                 .withHandlerAdapters(mockAdapter)

--- a/ask-sdk/src/com/amazon/ask/module/StandardSdkModule.java
+++ b/ask-sdk/src/com/amazon/ask/module/StandardSdkModule.java
@@ -1,0 +1,109 @@
+/*
+    Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+    except in compliance with the License. A copy of the License is located at
+
+        http://aws.amazon.com/apache2.0/
+
+    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+    the specific language governing permissions and limitations under the License.
+ */
+
+package com.amazon.ask.module;
+
+import com.amazon.ask.attributes.persistence.impl.DynamoDbPersistenceAdapter;
+import com.amazon.ask.model.RequestEnvelope;
+import com.amazon.ask.services.ApacheHttpApiClient;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+
+import java.util.function.Function;
+
+/**
+ * {@link SdkModule} that registers common add-on libraries shipped with the standard SDK distribution.
+ */
+public class StandardSdkModule implements SdkModule {
+
+    protected ApacheHttpApiClient apiClient;
+    protected DynamoDbPersistenceAdapter persistenceAdapter;
+
+    public StandardSdkModule(ApacheHttpApiClient apiClient, DynamoDbPersistenceAdapter persistenceAdapter) {
+        this.apiClient = apiClient;
+        this.persistenceAdapter = persistenceAdapter;
+    }
+
+    @Override
+    public void setupModule(SdkModuleContext context) {
+        context.setApiClient(apiClient);
+        context.setPersistenceAdapter(persistenceAdapter);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+
+        private Builder() {}
+
+        protected CloseableHttpClient customHttpClient;
+        protected AmazonDynamoDB customDynamoDBClient;
+        protected String tableName;
+        protected Boolean autoCreateTable;
+        protected Function<RequestEnvelope, String> partitionKeyGenerator;
+
+        public Builder withHttpClient(CloseableHttpClient customHttpClient) {
+            this.customHttpClient = customHttpClient;
+            return this;
+        }
+
+        public Builder withTableName(String tableName) {
+            this.tableName = tableName;
+            return this;
+        }
+
+        public Builder withAutoCreateTable(boolean autoCreateTable) {
+            this.autoCreateTable = autoCreateTable;
+            return this;
+        }
+
+        public Builder withPartitionKeyGenerator(Function<RequestEnvelope, String> partitionKeyGenerator) {
+            this.partitionKeyGenerator = partitionKeyGenerator;
+            return this;
+        }
+
+        public Builder withDynamoDbClient(AmazonDynamoDB customDynamoDBClient) {
+            this.customDynamoDBClient = customDynamoDBClient;
+            return this;
+        }
+
+        public StandardSdkModule build() {
+            DynamoDbPersistenceAdapter persistenceAdapter = null;
+
+            if (tableName != null) {
+                DynamoDbPersistenceAdapter.Builder persistenceAdapterBuilder = DynamoDbPersistenceAdapter.builder()
+                        .withTableName(tableName);
+                if (autoCreateTable != null) {
+                    persistenceAdapterBuilder.withAutoCreateTable(autoCreateTable);
+                }
+                if (partitionKeyGenerator != null) {
+                    persistenceAdapterBuilder.withPartitionKeyGenerator(partitionKeyGenerator);
+                }
+                if (customDynamoDBClient != null) {
+                    persistenceAdapterBuilder.withDynamoDbClient(customDynamoDBClient);
+                }
+                persistenceAdapter = persistenceAdapterBuilder.build();
+            }
+
+            ApacheHttpApiClient apiClient = ApacheHttpApiClient.custom()
+                    .withHttpClient(customHttpClient != null ? customHttpClient : HttpClients.createDefault())
+                    .build();
+            return new StandardSdkModule(apiClient, persistenceAdapter);
+        }
+
+    }
+
+}

--- a/ask-sdk/tst/com/amazon/ask/builder/StandardSkillBuilderTest.java
+++ b/ask-sdk/tst/com/amazon/ask/builder/StandardSkillBuilderTest.java
@@ -18,8 +18,8 @@ import com.amazon.ask.dispatcher.exception.ExceptionHandler;
 import com.amazon.ask.dispatcher.exception.ExceptionMapper;
 import com.amazon.ask.dispatcher.request.handler.HandlerInput;
 import com.amazon.ask.dispatcher.request.handler.RequestHandler;
-import com.amazon.ask.dispatcher.request.mapper.RequestMapper;
 import com.amazon.ask.dispatcher.request.handler.impl.DefaultHandlerAdapter;
+import com.amazon.ask.dispatcher.request.mapper.RequestMapper;
 import com.amazon.ask.dispatcher.request.mapper.impl.DefaultRequestMapper;
 import com.amazon.ask.model.Intent;
 import com.amazon.ask.model.IntentRequest;
@@ -28,9 +28,6 @@ import com.amazon.ask.services.ApacheHttpApiClient;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.Collections;
-import java.util.List;
 
 import static junit.framework.TestCase.assertNull;
 import static junit.framework.TestCase.assertTrue;


### PR DESCRIPTION
Introduces the concept of SDK modules, which are SDK extensions that can be registered on the SkillBuilder when setting up a Skill. Modules have a hook to configure themselves on the SkillConfiguration via an exposed module context when build() is called. This will allow add on libraries  to have a clean way to inject their own specific configuration, while avoiding the need to duplicate builder and configuration logic from the core SDK. This also eliminates the need for a complex builder hierarchy, as any configuration flavors can be injected through the use of modules.

This follows Jackson's module concept verbatim, which itself has a module setup hook and a module context that exposes hooks into the mapper builder.